### PR TITLE
Admins psay need to be always visible

### DIFF
--- a/addons/sourcemod/scripting/CustomChatColors.sp
+++ b/addons/sourcemod/scripting/CustomChatColors.sp
@@ -1608,7 +1608,7 @@ void SendPrivateChat(int client, int target, const char[] message)
 	}
 
 	#if defined _SelfMute_included_
-		if(!SelfMute_GetSelfMute(target, client))
+		if(!SelfMute_GetSelfMute(target, client) || CheckCommandAccess(client, "sm_kick", ADMFLAG_KICK, true))
 			CPrintToChat(target, "%s(Private to %s%N%s) %s%N {default}: %s%s", g_sSmCategoryColor, g_sSmNameColor, target,
 				g_sSmCategoryColor, g_sSmNameColor, client, g_sSmChatColor, message);
 	#else


### PR DESCRIPTION
If a player selfmuted an admin, the admin have to be still able to send private message and make it visible for the player (administration purpose)