### PR TITLE
fix: prevent Native error

### DIFF
--- a/addons/sourcemod/scripting/CustomChatColors.sp
+++ b/addons/sourcemod/scripting/CustomChatColors.sp
@@ -2186,9 +2186,12 @@ public Action OnClientSayCommand(int client, const char[] command, const char[] 
 #if defined _sourcecomms_included
 	if (g_bSourceComms && client)
 	{
-		int IsGagged = SourceComms_GetClientGagType(client);
-		if(IsClientInGame(client) && IsGagged > 0)
-			return Plugin_Continue;
+		if (IsClientInGame(client))
+		{
+			int IsGagged = SourceComms_GetClientGagType(client);
+			if (IsGagged > 0)
+				return Plugin_Continue;
+		}
 	}
 #endif
 	int startidx;


### PR DESCRIPTION
To prevent this kind of error.
```
L 04/15/2023 - 08:14:46: [SM] Exception reported: Client 47 is not in game
L 04/15/2023 - 08:14:46: [SM] Blaming: sourcebans/sbpp_comms.smx
L 04/15/2023 - 08:14:46: [SM] Call stack trace:
L 04/15/2023 - 08:14:46: [SM]   [0] ThrowNativeError
L 04/15/2023 - 08:14:46: [SM]   [1] Line 3399, sourcebanspp/addons/sourcemod/scripting/sbpp_comms.sp::Native_GetClientGagType
L 04/15/2023 - 08:14:46: [SM]   [3] SourceComms_GetClientGagType
L 04/15/2023 - 08:14:46: [SM]   [4] Line 2189, CustomChatColors/addons/sourcemod/scripting/CustomChatColors.sp::OnClientSayCommand
```