### PR TITLE
fix: resolve chat formatting and translation errors

### DIFF
--- a/addons/sourcemod/scripting/CustomChatColors.sp
+++ b/addons/sourcemod/scripting/CustomChatColors.sp
@@ -3883,7 +3883,7 @@ public bool IsClientEnabled()
 	return (HasFlag(g_msgAuthor, Admin_Generic) || HasFlag(g_msgAuthor, Admin_Custom1)) && g_iClientEnable[g_msgAuthor];
 }
 
-public Action Hook_UserMessage(UserMsg msg_id, BfRead bf, const int[] players, int playersNum, bool reliable, bool init)
+public Action Hook_UserMessage(UserMsg msg_id, Handle bf, const int[] players, int playersNum, bool reliable, bool init)
 {
 	char sAuthorTag[64];
 
@@ -3904,13 +3904,13 @@ public Action Hook_UserMessage(UserMsg msg_id, BfRead bf, const int[] players, i
 		BfReadString(bf, g_msgText, sizeof(g_msgText), false);
 	}
 
-	if (g_msgAuthor < 1 || g_msgAuthor > MaxClients)
+	if (g_msgAuthor < 0 || g_msgAuthor > MaxClients)
 		return Plugin_Continue;
 
 	if (strlen(g_msgName) == 0 || strlen(g_msgSender) == 0)
 		return Plugin_Continue;
 
-	if (!strcmp(g_msgName, "#Cstrike_Name_Change") || strncmp(g_msgName, "#Cstrike", 8, false) != 1)
+	if (!strcmp(g_msgName, "#Cstrike_Name_Change"))
 		return Plugin_Continue;
 
 	TrimString(g_msgText);
@@ -3970,11 +3970,13 @@ public Action Hook_UserMessage(UserMsg msg_id, BfRead bf, const int[] players, i
 	char sValue[32];
 	if (!bIsAction && IsClientEnabled())
 	{
-		if (bNameFound)
-			Format(g_msgSender, sizeof(g_msgSender), "{%s%s}%s", CCC_GetColor(sNameColorKey, sValue, sizeof(sValue)) ? "#" : "", sNameColorKey, g_msgSender);
+		if (!bNameFound)
+			sNameColorKey = "teamcolor";
+
+		Format(g_msgSender, sizeof(g_msgSender), "{%s%s}%s", CCC_GetColor(sNameColorKey, sValue, sizeof(sValue)) ? "#" : "", sNameColorKey, g_msgSender);
 
 		if (strlen(sAuthorTag) > 0)
-			Format(g_msgSender, sizeof(g_msgSender), "{%s%s}%s%s%s", CCC_GetColor(sTagColorKey, sValue, sizeof(sValue)) ? "#" : "", bTagFound ? sTagColorKey : "default", sAuthorTag, bNameFound ? "" : "{teamcolor}", g_msgSender);
+			Format(g_msgSender, sizeof(g_msgSender), "{%s%s}%s%s", CCC_GetColor(sTagColorKey, sValue, sizeof(sValue)) ? "#" : "", bTagFound ? sTagColorKey : "default", sAuthorTag, g_msgSender);
 
 		StringMap smTrie = CGetTrie();
 		if (g_msgText[0] == '>' && GetConVarInt(g_cvar_GreenText) > 0 && smTrie.GetString("green", sValue, sizeof(sValue)))
@@ -3992,7 +3994,7 @@ public Action Hook_UserMessage(UserMsg msg_id, BfRead bf, const int[] players, i
 	}
 
 	SetGlobalTransTarget(LANG_SERVER);
-	Format(g_msgFinal, sizeof(g_msgFinal), "%T", g_msgName, LANG_SERVER, g_msgSender, g_msgText);
+	Format(g_msgFinal, sizeof(g_msgFinal), "%t", g_msgName, g_msgSender, g_msgText);
 
 	if (!g_msgAuthor || IsClientEnabled())
 	{

--- a/addons/sourcemod/scripting/CustomChatColors.sp
+++ b/addons/sourcemod/scripting/CustomChatColors.sp
@@ -3993,7 +3993,7 @@ public Action Hook_UserMessage(UserMsg msg_id, Handle bf, const int[] players, i
 		CFormatColor(g_msgSender, sizeof(g_msgSender), g_msgAuthor);
 	}
 
-	SetGlobalTransTarget(LANG_SERVER);
+	SetGlobalTransTarget(g_msgAuthor);
 	Format(g_msgFinal, sizeof(g_msgFinal), "%t", g_msgName, g_msgSender, g_msgText);
 
 	if (!g_msgAuthor || IsClientEnabled())

--- a/addons/sourcemod/scripting/CustomChatColors.sp
+++ b/addons/sourcemod/scripting/CustomChatColors.sp
@@ -15,7 +15,7 @@
 #tryinclude <DynamicChannels>
 #define REQUIRE_PLUGIN
 
-#define PLUGIN_VERSION					"7.4.9"
+#define PLUGIN_VERSION					"7.4.10"
 
 #define DATABASE_NAME					"ccc"
 
@@ -3883,7 +3883,7 @@ public bool IsClientEnabled()
 	return (HasFlag(g_msgAuthor, Admin_Generic) || HasFlag(g_msgAuthor, Admin_Custom1)) && g_iClientEnable[g_msgAuthor];
 }
 
-public Action Hook_UserMessage(UserMsg msg_id, Handle bf, const int[] players, int playersNum, bool reliable, bool init)
+public Action Hook_UserMessage(UserMsg msg_id, BfRead bf, const int[] players, int playersNum, bool reliable, bool init)
 {
 	char sAuthorTag[64];
 
@@ -3904,10 +3904,13 @@ public Action Hook_UserMessage(UserMsg msg_id, Handle bf, const int[] players, i
 		BfReadString(bf, g_msgText, sizeof(g_msgText), false);
 	}
 
+	if (g_msgAuthor < 1 || g_msgAuthor > MaxClients)
+		return Plugin_Continue;
+
 	if (strlen(g_msgName) == 0 || strlen(g_msgSender) == 0)
 		return Plugin_Continue;
 
-	if (!strcmp(g_msgName, "#Cstrike_Name_Change"))
+	if (!strcmp(g_msgName, "#Cstrike_Name_Change") || strncmp(g_msgName, "#Cstrike", 8, false) != 1)
 		return Plugin_Continue;
 
 	TrimString(g_msgText);
@@ -3971,7 +3974,7 @@ public Action Hook_UserMessage(UserMsg msg_id, Handle bf, const int[] players, i
 			Format(g_msgSender, sizeof(g_msgSender), "{%s%s}%s", CCC_GetColor(sNameColorKey, sValue, sizeof(sValue)) ? "#" : "", sNameColorKey, g_msgSender);
 
 		if (strlen(sAuthorTag) > 0)
-			Format(g_msgSender, sizeof(g_msgSender), "{%s%s}%s%s", CCC_GetColor(sTagColorKey, sValue, sizeof(sValue)) ? "#" : "", bTagFound ? sTagColorKey : "default", sAuthorTag, g_msgSender);
+			Format(g_msgSender, sizeof(g_msgSender), "{%s%s}%s%s%s", CCC_GetColor(sTagColorKey, sValue, sizeof(sValue)) ? "#" : "", bTagFound ? sTagColorKey : "default", sAuthorTag, bNameFound ? "" : "{teamcolor}", g_msgSender);
 
 		StringMap smTrie = CGetTrie();
 		if (g_msgText[0] == '>' && GetConVarInt(g_cvar_GreenText) > 0 && smTrie.GetString("green", sValue, sizeof(sValue)))
@@ -3988,7 +3991,8 @@ public Action Hook_UserMessage(UserMsg msg_id, Handle bf, const int[] players, i
 		CFormatColor(g_msgSender, sizeof(g_msgSender), g_msgAuthor);
 	}
 
-	Format(g_msgFinal, sizeof(g_msgFinal), "%t", g_msgName, g_msgSender, g_msgText);
+	SetGlobalTransTarget(LANG_SERVER);
+	Format(g_msgFinal, sizeof(g_msgFinal), "%T", g_msgName, LANG_SERVER, g_msgSender, g_msgText);
 
 	if (!g_msgAuthor || IsClientEnabled())
 	{
@@ -4002,9 +4006,7 @@ public Action Hook_UserMessage(UserMsg msg_id, Handle bf, const int[] players, i
 public Action Event_PlayerSay(Handle event, const char[] name, bool dontBroadcast)
 {
 	if (g_msgAuthor == -1 || GetClientOfUserId(GetEventInt(event, "userid")) != g_msgAuthor)
-	{
 		return Plugin_Continue;
-	}
 
 	if (strlen(g_msgText) == 0)
 		return Plugin_Continue;
@@ -4054,17 +4056,17 @@ public Action Event_PlayerSay(Handle event, const char[] name, bool dontBroadcas
 		PbAddString(SayText2, "params", "");
 		PbAddString(SayText2, "params", "");
 		PbAddString(SayText2, "params", "");
-		EndMessage();
 	}
 	else
 	{
 		BfWriteByte(SayText2, g_msgAuthor);
 		BfWriteByte(SayText2, g_msgIsChat);
 		BfWriteString(SayText2, g_msgFinal);
-		EndMessage();
 	}
 
+	EndMessage();
 	g_msgAuthor = -1;
+
 	return Plugin_Continue;
 }
 


### PR DESCRIPTION
Fixes two issues related to chat formatting and translation failures:  

1. Chat Formatting Bug (#46)   
   - Corrected the behavior where the player's name was printed with the tag color when no name color was set.   
   - Now, if `namecolor` is null, the player's name will use the `teamcolor` instead of the `tagcolor`.  

2. Translation Failure Bug (#44):   
   - Addressed an exception caused by an invalid client index during translation.  
   - Added a check to ensure that the language phrase is what we aim for before attempting to format the message.  

These changes improve the stability and usability of the chat system.