### PR TITLE
Harden CCC persistence: userID-safe datapacks, immediate tag/color save, no DB on disconnect

### DIFF
--- a/addons/sourcemod/scripting/CustomChatColors.sp
+++ b/addons/sourcemod/scripting/CustomChatColors.sp
@@ -1886,7 +1886,13 @@ stock bool SetColor(char Key[64], char HEX[64], int client, bool IgnoreBan=false
 	else
 		current[0] = '\0';
 
-	if (current[0] != '\0' && strcmp(current, HEX, false) == 0)
+	// Normalize current value by stripping leading '#'
+	char normalizedCurrent[32];
+	strcopy(normalizedCurrent, sizeof(normalizedCurrent), current);
+	if (normalizedCurrent[0] == '#')
+		ReplaceString(normalizedCurrent, sizeof(normalizedCurrent), "#", "");
+
+	if (normalizedCurrent[0] != '\0' && strcmp(normalizedCurrent, HEX, false) == 0)
 		return true;
 
 	if (strcmp(Key, "tagcolor", false) == 0)

--- a/addons/sourcemod/scripting/CustomChatColors.sp
+++ b/addons/sourcemod/scripting/CustomChatColors.sp
@@ -1625,23 +1625,23 @@ bool MakeStringPrintable(char[] str, int str_len_max, const char[] empty) //func
 		{
 			if (str[r] < '\x20')
 			{
-			modified = true;
+				modified = true;
 
-			if((str[r] == '\n' || str[r] == '\t') && w > 0 && str[w-1] != '\x20')
+			if ((str[r] == '\n' || str[r] == '\t') && w > 0 && str[w-1] != '\x20')
 				addspace = true;
 			}
 			else
 			{
-			if (str[r] != '\x20')
-			{
-				nonspace = true;
+				if (str[r] != '\x20')
+				{
+					nonspace = true;
 
-				if (addspace)
-				str[w++] = '\x20';
-			}
+					if (addspace)
+						str[w++] = '\x20';
+				}
 
-			addspace = false;
-			str[w++] = str[r];
+				addspace = false;
+				str[w++] = str[r];
 			}
 		}
 		while(str[++r]);

--- a/addons/sourcemod/scripting/include/ccc.inc
+++ b/addons/sourcemod/scripting/include/ccc.inc
@@ -11,7 +11,7 @@
 
 #define CCC_V_MAJOR   "7"
 #define CCC_V_MINOR   "4"
-#define CCC_V_PATCH   "17"
+#define CCC_V_PATCH   "18"
 
 #define CCC_VERSION            CCC_V_MAJOR..."."...CCC_V_MINOR..."."...CCC_V_PATCH
 


### PR DESCRIPTION
- Switch all SQL datapacks to userIDs and resolve via GetClientOfUserId in callbacks with early returns
- Remove DB writes from OnClientDisconnect to avoid mass writes on map changes; always clean runtime state
- Persist tag/color/enable changes immediately:
  - SetTag persists (requires DB connected)
  - SetColor persists only when value actually changes; normalizes HEX and avoids redundant queries
- Fix SQL format bug in tag UPDATE (name: %d → %s)
- Escape player names in ban INSERT/UPDATE to prevent SQL issues
- Align BanCCC datapack write/read order (targetSid then clientSid)
- Lower priority for non-critical selects (ban/tag/group) to reduce DB pressure
- Make group select userID-safe (SQLSelect_TagGroup + OnSQLSelect_TagGroup)
- Make tag selects userID-safe (OnSQLSelect_Tag)
- Keep replace triggers userID-safe and retry-stable

Testing notes:
- Verified no DB writes on disconnect; values persist on change only
- Checked retry paths reuse the same DataPack and guard against slot reuse
- Linter passes